### PR TITLE
Timeout SSH wait after 5 minutes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,3 @@ dependencies:
   - boto3=1.9.31
   - python=3.7.0
   - fabric=2.4.0
-


### PR DESCRIPTION
This PR modifies the SSH wait method so that it errors after 5 minutes. Previously we errored after 60 attempts assuming it was close to 5 minutes. But since the time it takes for each connection attempt to error is unpredictable, this should be a better solution.