### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These variables can be [passed into the Docker run](https://docs.docker.com/engi
 
 ```sh
 $ cp .env.sample .env # Fill out .env file
-$ docker build -t run-on-ec2 .
+$ docker pull surfline/run-on-ec2
 $ docker run --rm -it --env-file=.env run-on-ec2 echo \"hello world\"
 
 Creating key pair run-on-ec2-eb5f9910-1635-40e1-b120-0e08b06a60ce...


### PR DESCRIPTION
Instructions for using the Docker image should have the user pull the image rather than build it from the repository.