### PR TITLE
PS-547 - Fix Termination Behavior for EC2 Instance

### DIFF
--- a/lib/ec2.py
+++ b/lib/ec2.py
@@ -113,7 +113,7 @@ class TempInstance():
     def __enter__(self):
         try:
             return self.__launch_instance()
-        finally:
+        except:
             self.__exit__(*sys.exc_info())
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
Issues:
https://wavetrak.atlassian.net/secure/RapidBoard.jspa?rapidView=120&modal=detail&selectedIssue=PS-547&assignee=5cf98b5fb06c540e8258102f

Replacing `except` with `finally` turned out to be problematic in practice, because a long running EC2 instance will be terminated prematurely. Reverted this change. 