### PR TITLE
Lock invoke version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 **/__pycache__/
 **/*.py[cod]
 **/*$py.class
+.mypy_cache/
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.mypy_cache/
 .env

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,6 @@ channels:
   - defaults
 dependencies:
   - boto3=1.9.31
+  - invoke=1.2.0
   - python=3.7.0
   - fabric=2.4.0


### PR DESCRIPTION
This PR locks the version of `invoke` to avoid `1.3.0`, which introduces a breaking change ( https://github.com/pyinvoke/invoke/issues/654).